### PR TITLE
Prefix duplicate find bug

### DIFF
--- a/lib/trie.ex
+++ b/lib/trie.ex
@@ -150,8 +150,9 @@ defmodule KrDict.Trie do
       {%TrieNode{children: children}, match} ->
         children
         |> Enum.flat_map(fn {val, _node} ->
-          [match] ++ do_prefix_lookup(trie, match <> <<val::utf8>>)
+          do_prefix_lookup(trie, match <> <<val::utf8>>)
         end)
+        |> List.insert_at(0, match)
     end
   end
 end

--- a/test/kr_dict_test.exs
+++ b/test/kr_dict_test.exs
@@ -1,9 +1,3 @@
 defmodule KrDictTest do
   use ExUnit.Case
-  doctest KrDict
-  gom = "boo"
-  @tag :bops
-  test "greets the world #{gom}" do
-    assert KrDict.hello() == :world
-  end
 end

--- a/test/trie_test.exs
+++ b/test/trie_test.exs
@@ -239,8 +239,8 @@ defmodule TrieTest do
     assert found == []
   end
 
-  @tag :regression
-  test "prefix/3 replicate error" do
+  @tag :trie_prefix
+  test "prefix/2 when subsequent nodes have many other nodes" do
     found = Trie.insert("공")
       |> Trie.insert("공항")
       |> Trie.insert("공부")

--- a/test/trie_test.exs
+++ b/test/trie_test.exs
@@ -173,7 +173,7 @@ defmodule TrieTest do
   end
 
   @tag :trie_prefix
-  test "prefix/3 deals with empty string" do
+  test "prefix/2 deals with empty string" do
     found =
       Trie.insert("ㄱㅗㅇㄱㅣ")
       |> Trie.insert("ㄱㅗㅇㄱㅣㅂㅏㅂ")
@@ -184,7 +184,7 @@ defmodule TrieTest do
   end
 
   @tag :trie_prefix
-  test "prefix/3 find a word if only one word that shares the prefix" do
+  test "prefix/2 find a word if only one word that shares the prefix" do
     found =
       Trie.insert("공")
       |> Trie.insert("밥")
@@ -195,7 +195,7 @@ defmodule TrieTest do
   end
 
   @tag :trie_prefix
-  test "prefix/3 find any words that share a prefix" do
+  test "prefix/2 find any words that share a prefix" do
     found =
       Trie.insert("공")
       |> Trie.insert("밥")
@@ -207,7 +207,7 @@ defmodule TrieTest do
   end
 
   @tag :trie_prefix
-  test "prefix/3 will return the prefix as well if it is a word" do
+  test "prefix/2 will return the prefix as well if it is a word" do
     found =
       Trie.insert("공기")
       |> Trie.insert("공기밥")
@@ -218,7 +218,7 @@ defmodule TrieTest do
   end
 
   @tag :trie_prefix
-  test "prefix/3 will not return the prefix as well if it is not a word" do
+  test "prefix/2 will not return the prefix as well if it is not a word" do
     found =
       Trie.insert("공기")
       |> Trie.insert("공기밥")
@@ -229,7 +229,7 @@ defmodule TrieTest do
   end
 
   @tag :trie_prefix
-  test "prefix/3 will not return anything if there are no matching prefixes" do
+  test "prefix/2 will not return anything if there are no matching prefixes" do
     found =
       Trie.insert("공기")
       |> Trie.insert("공기밥")
@@ -237,5 +237,18 @@ defmodule TrieTest do
       |> Trie.prefix("물")
 
     assert found == []
+  end
+
+  @tag :regression
+  test "prefix/3 replicate error" do
+    found = Trie.insert("공")
+      |> Trie.insert("공항")
+      |> Trie.insert("공부")
+      |> Trie.insert("공항버스")
+      |> Trie.insert("방귀")
+      |> Trie.insert("진우")
+      |> Trie.prefix("공")
+
+    assert found == ["공", "공부", "공항", "공항버스"]
   end
 end


### PR DESCRIPTION
Fixed an issue where if a node had many children, the parent value would get added many times to the list